### PR TITLE
ロゴを押したときの時のページ遷移を変更

### DIFF
--- a/twitter_clone/src/resources/views/layouts/app.blade.php
+++ b/twitter_clone/src/resources/views/layouts/app.blade.php
@@ -20,7 +20,7 @@
         <div id="app">
             <nav class="navbar navbar-expand-md navbar-light bg-white shadow-sm">
                 <div class="container">
-                    <a class="navbar-brand" href="{{ url('/') }}">
+                    <a class="navbar-brand" href="{{ route('tweets.index') }}">
                         ツッタカター
                     </a>
                     <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="{{ __('Toggle navigation') }}">


### PR DESCRIPTION
## 概要
ロゴ押すとログイン画面に遷移するのでタイムライン画面に変更

### Ticket/Issuesリンク
ロゴ押すとログイン画面に遷移 https://github.com/nanbakeito/twitter_clone/issues/27

### なぜこのタスクを行うのか
ログイン状態からログイン画面に遷移するのは不自然
### やったこと
ログイン画面からタイムライン画面に遷移するように変更