### PR TITLE
通信失敗後ボタンが不活性化するエラー修正

### DIFF
--- a/twitter_clone/src/resources/js/components/ProfileTweet.vue
+++ b/twitter_clone/src/resources/js/components/ProfileTweet.vue
@@ -182,6 +182,7 @@ export default {
                 this.isActivePost = false;
             }).catch((error) => {
                 alert("テキストを入れてください");
+                this.isActivePost = false;
             });
         },
 

--- a/twitter_clone/src/resources/js/components/Tweet.vue
+++ b/twitter_clone/src/resources/js/components/Tweet.vue
@@ -219,6 +219,7 @@ export default {
                 this.isActivePost = false;
             }).catch((error) => {
                 alert("テキストを入れてください");
+                this.isActivePost = false;
             });
         },
 

--- a/twitter_clone/src/resources/js/components/comment/Comment.vue
+++ b/twitter_clone/src/resources/js/components/comment/Comment.vue
@@ -83,6 +83,7 @@ export default {
                 this.isActive = false;
             }).catch((error) => {
                 alert("テキストを入れてください");
+                this.isActive = false;
             });
         },
         remove(id) {


### PR DESCRIPTION
close #29 
## 概要
投稿時、通信失敗後ボタンが不活性化するエラー修正

### Ticket/Issuesリンク
#29

### やったこと
通信失敗後ボタンが不活性化するエラー修正
・catchエラー時にボタンを活性化させる処理を追加
